### PR TITLE
ExtractFromUnion: Call ReleaseWave only for free waves

### DIFF
--- a/src/CallFunctionParameterHandler.cpp
+++ b/src/CallFunctionParameterHandler.cpp
@@ -65,7 +65,7 @@ json ExtractFromUnion(IgorTypeUnion *ret, int igorType)
     {
       auto result = SerializeWave(ret->waveHandle);
 
-      if(ret->waveHandle != nullptr)
+      if(ret->waveHandle != nullptr && IsFreeWave(ret->waveHandle))
       {
         ReleaseWave(&ret->waveHandle);
         ret->waveHandle = nullptr;

--- a/src/HelperFunctions.cpp
+++ b/src/HelperFunctions.cpp
@@ -715,3 +715,12 @@ void EnsureDirectoryExists(const std::string &path)
 
   throw IgorException(ret);
 }
+
+bool IsFreeWave(waveHndl wv)
+{
+  DataFolderHandle dfH = nullptr;
+  int rc               = GetWavesDataFolder(wv, &dfH);
+  ASSERT(rc == 0);
+
+  return dfH == nullptr;
+}

--- a/src/HelperFunctions.h
+++ b/src/HelperFunctions.h
@@ -208,3 +208,5 @@ void xop_logging(OutputMode mode, const char *func, int line, const S &format,
 int CreateDirectory(const std::string &path);
 
 void EnsureDirectoryExists(const std::string &path);
+
+bool IsFreeWave(waveHndl wv);


### PR DESCRIPTION
The current version outputs a "BUG: ..." message when trying to release
a permanent wave returned by a function.

According to WM support this is an Igor Pro bug present in 8 and current
versions of 9.

A workaround is to call ReleaseWave only on free waves.

Close #24.