### PR TITLE
.gitlab-ci.yml: Fix coverage artifacts again

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -330,9 +330,8 @@ coverage:
   coverage: '/TOTAL.+ (\d+\.\d+%)$/'
   artifacts:
     paths:
-      - build/coverage
-    exclude:
-      - build/coverage/coverage
+      - build/coverage/*.html
+      - build/coverage/*.css
   needs:
       - compile-xop-debug-coverage-macosx
       - download-xoptoolkit


### PR DESCRIPTION
The fix in c5cee96f (.gitlab-ci.yml: Exclude unused artifacts from
coverage job, 2021-03-29) was not complete.