### PR TITLE
feat: remove CMAKE_BUILD_TYPE from cmake build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -132,7 +132,7 @@ compile-xop-windows:
     - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %ARCHITECTURE%
     - md build
     - cd build
-    - cmake -G "Visual Studio 16 2019" -A %GENERATOR_PLATFORM% -DCMAKE_BUILD_TYPE=%CONFIG_TYPE% -DMSVC_RUNTIME_DYNAMIC=ON -DWARNINGS_AS_ERRORS=ON ../src
+    - cmake -G "Visual Studio 16 2019" -A %GENERATOR_PLATFORM% -DMSVC_RUNTIME_DYNAMIC=ON -DWARNINGS_AS_ERRORS=ON ../src
     - cmake --build . --config %CONFIG_TYPE% --target install
   needs:
     - download-xoptoolkit
@@ -147,7 +147,7 @@ compile-xop-release-macosx:
   script:
     - mkdir build
     - cd build
-    - cmake -G "Xcode" -DCMAKE_BUILD_TYPE=Release -DWARNINGS_AS_ERRORS=ON ../src
+    - cmake -G "Xcode" -DWARNINGS_AS_ERRORS=ON ../src
     - cmake --build . --config Release --target install
   needs:
     - download-xoptoolkit
@@ -162,7 +162,7 @@ compile-xop-debug-coverage-macosx:
   script:
     - mkdir build
     - cd build
-    - cmake -G "Xcode" -DCMAKE_BUILD_TYPE=Debug -DWARNINGS_AS_ERRORS=ON -DCOVERAGE=ON -DSANITIZER=ON ../src
+    - cmake -G "Xcode" -DWARNINGS_AS_ERRORS=ON -DCOVERAGE=ON -DSANITIZER=ON ../src
     - cmake --build . --config Debug --target install
   needs:
     - download-xoptoolkit
@@ -181,7 +181,7 @@ clang-tidy:
   script:
     - mkdir build
     - cd build
-    - cmake -G "Unix Makefiles" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug ../src
+    - cmake -G "Unix Makefiles" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../src
     - cmake --build . --config Debug --target clang-tidy && exit_value=$? || exit_value=$?
     - git commit -m "clang-tidy fixes" ..
     - git format-patch -n1
@@ -343,7 +343,7 @@ coverage:
       - mkdir -p build/coverage
       - mv tests/default.profraw build/coverage
       - cd build
-      - cmake -G "Xcode" -DCOVERAGE=ON -DCMAKE_BUILD_TYPE=Debug ../src
+      - cmake -G "Xcode" -DCOVERAGE=ON ../src
       - cmake --build . --config Debug --target install
       - cmake --build . --target coverage
   coverage: '/^TOTAL.*\s+(\d+\%)$/'

--- a/Readme.rst
+++ b/Readme.rst
@@ -604,16 +604,16 @@ The commands below perform this. (See also ``.gitlab.ci.yml`` for up-do-date bui
    cd $zmq-xop-dir/src
    md build build-64
    cd build
-   cmake -G "Visual Studio 16 2019" -A Win32 -DCMAKE_BUILD_TYPE=Release -S .. -B .
+   cmake -G "Visual Studio 16 2019" -A Win32 -S .. -B .
    cmake --build . --config Release --target install
    cd ../build-64
-   cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=Release -S .. -B .
+   cmake -G "Visual Studio 16 2019" -A x64 -S .. -B .
    cmake --build . --config Release --target install
    # }
 
    # MacOSX
    # {
-   cmake -G Xcode -DCMAKE_BUILD_TYPE=Release -S .. -B .
+   cmake -G Xcode -S .. -B .
    cmake --build . --config Release --target install
    # }
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,14 +13,14 @@ SET_TARGET_PROPERTIES(${prog} PROPERTIES CXX_STANDARD 11)
 # (Taken from src/CMakeLists.txt, to determine libzmq path. Yes, this could be
 # copied into its own CMake module, but I'm not sure it's necessary right now...)
 IF(APPLE)
-  SET(installFolderLibZMQ "${CMAKE_SOURCE_DIR}/../output/mac/libzmq/${CMAKE_BUILD_TYPE}")
+  SET(installFolderLibZMQ "${CMAKE_SOURCE_DIR}/../output/mac/libzmq/$<CONFIG>")
 ELSEIF(WIN32)
   IF(CMAKE_SIZEOF_VOID_P EQUAL 4)
     SET(bitnessLibFolder "x86")
   ELSEIF(CMAKE_SIZEOF_VOID_P EQUAL 8)
     SET(bitnessLibFolder "x64")
   ENDIF()
-  SET(installFolderLibZMQ "${CMAKE_SOURCE_DIR}/../output/win/${bitnessLibFolder}/libzmq/${CMAKE_BUILD_TYPE}")
+  SET(installFolderLibZMQ "${CMAKE_SOURCE_DIR}/../output/win/${bitnessLibFolder}/libzmq/$<CONFIG>")
 ENDIF()
 
 TARGET_LINK_LIBRARIES(${prog}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,17 +15,15 @@ if(APPLE)
   SET(CMAKE_OSX_DEPLOYMENT_TARGET "10.10" CACHE STRING "Minimum MacOSX version")
 endif()
 
+# Limit multigenerator configs to Debug and Release for now (only ones used).
+SET(CMAKE_CONFIGURATION_TYPES "Debug;Release")
+
 PROJECT(ZeroMQ)
 
 OPTION(COVERAGE "Enable coverage instrumentation" OFF)
 OPTION(SANITIZER "Enable sanitizer instrumentation" OFF)
 OPTION(MSVC_RUNTIME_DYNAMIC "Link dynamically against the MSVC runtime library" OFF)
 OPTION(WARNINGS_AS_ERRORS "Error out on compiler warnings" OFF)
-
-IF(NOT CMAKE_BUILD_TYPE)
-  SET(CMAKE_BUILD_TYPE "Debug")
-  MESSAGE(STATUS "CMAKE_BUILD_TYPE is not set, setting to CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}.")
-ENDIF()
 
 # Define minimum version based on XOP Toolkit. If compiling for Igor 6/7,
 # set to 637 when calling cmake: cmake -DXOP_MINIMUM_IGORVERSION=637...
@@ -88,14 +86,14 @@ IF(APPLE)
   SET_SOURCE_FILES_PROPERTIES(${RESOURCES} PROPERTIES GENERATED TRUE)
   SET(RESOURCE_CONFIG "${PROJECT_NAME}.r")
 
-  SET(installFolder "${CMAKE_SOURCE_DIR}/../output/mac/xop/${CMAKE_BUILD_TYPE}")
-  SET(installFolderLibZMQ "${CMAKE_SOURCE_DIR}/../output/mac/libzmq/${CMAKE_BUILD_TYPE}")
+  SET(installFolder "${CMAKE_SOURCE_DIR}/../output/mac/xop/$<CONFIG>")
+  SET(installFolderLibZMQ "${CMAKE_SOURCE_DIR}/../output/mac/libzmq/$<CONFIG>")
 ELSEIF(WIN32)
   SET(RESOURCES "${PROJECT_NAME}.rc")
   SET(RESOURCE_CONFIG "${PROJECT_NAME}WinCustom.rc")
 
-  SET(installFolder "${CMAKE_SOURCE_DIR}/../output/win/${bitnessLibFolder}/xop/${CMAKE_BUILD_TYPE}")
-  SET(installFolderLibZMQ "${CMAKE_SOURCE_DIR}/../output/win/${bitnessLibFolder}/libzmq/${CMAKE_BUILD_TYPE}")
+  SET(installFolder "${CMAKE_SOURCE_DIR}/../output/win/${bitnessLibFolder}/xop/$<CONFIG>")
+  SET(installFolderLibZMQ "${CMAKE_SOURCE_DIR}/../output/win/${bitnessLibFolder}/libzmq/$<CONFIG>")
 ENDIF()
 
 # Create necessary resource files from intermediaries
@@ -466,19 +464,34 @@ CONFIGURE_FILE(git_version.cpp.in git_version.cpp @ONLY)
 CONFIGURE_FILE(cmake_config.h.in cmake_config.h @ONLY)
 
 IF(MSVC)
-  IF(${CMAKE_BUILD_TYPE} MATCHES "Debug")
-    SET(CMAKE_INSTALL_DEBUG_LIBRARIES_ONLY TRUE)
-    SET(CMAKE_INSTALL_DEBUG_LIBRARIES TRUE)
-  ENDIF()
+  # Get runtime libraries (debug and not) to configure for install.
+  SET(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP TRUE)  # We will call ourselves
 
-  SET(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION ${installFolder})
+  # Get release libraries
   INCLUDE(InstallRequiredSystemLibraries)
+  SET(WIN_RUNTIME_RELEASE ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS})
+
+  # Reset module variable between calls.
+  SET(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS "")
+
+  # Get debug libraries
+  SET(CMAKE_INSTALL_DEBUG_LIBRARIES_ONLY TRUE)
+  SET(CMAKE_INSTALL_DEBUG_LIBRARIES TRUE)
+  INCLUDE(InstallRequiredSystemLibraries)
+  SET(WIN_RUNTIME_DEBUG ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS})
+
+  INSTALL(PROGRAMS ${WIN_RUNTIME_DEBUG}
+          DESTINATION ${installFolder}
+          CONFIGURATIONS Debug)
+  INSTALL(PROGRAMS ${WIN_RUNTIME_RELEASE}
+          DESTINATION ${installFolder}
+          CONFIGURATIONS Release)
 
   INSTALL(TARGETS ${libname}
           RUNTIME
           DESTINATION ${installFolder})
 
-  INSTALL(FILES ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/${libname}.pdb
+  INSTALL(FILES ${CMAKE_BINARY_DIR}/$<CONFIG>/${libname}.pdb
           DESTINATION ${installFolder})
 
   INSTALL(FILES ${installFolderLibZMQ}/bin/libzmq-v142-mt-gd-4_3_4.dll


### PR DESCRIPTION
----------------
NOTE: If this is interesting, I would prefer pushing it *after* the other pull request. I will make the changes of this if/when the other is pulled. I simply wanted to make you aware of this optional change before I forget.
----------------

While working on something else, I realized that the CMakeLists and associated readmes use a mix of `$<CONFIG>` and `${CMAKE_BUILD_TYPE}` for the configuration. Since the supported generators are xcode for OSX and Visual Studio for Mac, it may make sense to replace associated `CMAKE_BUILD_TYPE` logic with the appropriate `$<CONFIG>` generator expressions. This changelist does that.

NOTE: By removing `${CMAKE_BUILD_TYPE}`, this changelist effectively breaks the possibility of building using UNIX Makefiles, which *could* in principle be a desired generator on OSX. If so, this changelist should not be accepted!

In terms of changes, we primarily simply replace the cmake variable with the generator expression, where appropriate. The noteworthy changes are:

- Tied to InstallRequiredSystemVariables, in src/CMakeLists.txt: Since this function does not support generator expressions, we run it 2x, setting a local variable with the runtime libraries between them. Once done, we manually invoke install(PROGRAMS) calls for Release and Debug configurations.
- Since this CMake seems to be based around only Debug and Release builds, we limit the configurations to those 2 options.