### PR TITLE
.gitlab-ci.yml: Prefer FTP_URL variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -368,4 +368,4 @@ symbol_creation_and_upload:
     - mkdir symbols
     - symstore -z symbols output/win/x64/xop/Release/*.pdb output/win/x64/xop/Release/*.xop
     - symstore -z symbols output/win/x86/xop/Release/*.pdb output/win/x86/xop/Release/*.xop
-    - lftp -e "mirror --reverse -n symbols /; bye" -u $FTP_SYMBOLS_USER,$FTP_SYMBOLS_PASS ftp.byte-physics.de
+    - lftp -e "mirror --reverse -n symbols /; bye" -u $FTP_SYMBOLS_USER,$FTP_SYMBOLS_PASS $FTP_URL


### PR DESCRIPTION
This prepares for the hosting migration from hosteurope to hetzner.