### PR TITLE
procedures: Fix grouping commands for newer doxygen versions 1.12.0

### DIFF
--- a/procedures/ZeroMQ_Interop.ipf
+++ b/procedures/ZeroMQ_Interop.ipf
@@ -8,7 +8,7 @@
 #if igorVersion() >= 8
 /// @name Flags for zeromq_set()
 /// @anchor ZeroMQSetFlags
-/// @{
+///@{
 /// Sets the default flags (no debug, no ipv6, busy wait on receive)
 Constant ZeroMQ_SET_FLAGS_DEFAULT = 0x1
 /// Enable debug output
@@ -21,13 +21,13 @@ Constant ZeroMQ_SET_FLAGS_NOBUSYWAITRECV = 0x8
 /// Log incoming and outgoing messages
 Constant ZeroMQ_SET_FLAGS_LOGGING = 0x10
 
-/// @}
+///@}
 
 StrConstant ZeroMQ_HEARTBEAT = "heartbeat"
 
 /// @name Error codes
 /// @anchor ZeroMQErrorCodes
-/// @{
+///@{
 Constant ZeroMQ_UNKNOWN_SET_FLAG          = 10003
 Constant ZeroMQ_INTERNAL_ERROR            = 10004
 Constant ZeroMQ_INVALID_ARG               = 10005
@@ -39,12 +39,12 @@ Constant ZeroMQ_INVALID_LOGGING_TEMPLATE  = 10010
 Constant ZeroMQ_MESSAGE_FILTER_DUPLICATED = 10011
 Constant ZeroMQ_MESSAGE_FILTER_MISSING    = 10012
 Constant ZeroMQ_MESSAGE_INVALID_TYPE      = 10013
-/// @}
+///@}
 #endif
 
 /// @name Flags for zeromq_set()
 /// @anchor ZeroMQSetFlags
-/// @{
+///@{
 /// Sets the default flags (no debug, no ipv6, busy wait on receive)
 Constant ZMQ_SET_FLAGS_DEFAULT = 0x1
 /// Enable debug output
@@ -57,13 +57,13 @@ Constant ZMQ_SET_FLAGS_NOBUSYWAITRECV = 0x8
 /// Log incoming and outgoing messages
 Constant ZMQ_SET_FLAGS_LOGGING = 0x10
 
-/// @}
+///@}
 
 StrConstant ZMQ_HEARTBEAT = "heartbeat"
 
 /// @name Error codes
 /// @anchor ZeroMQErrorCodes
-/// @{
+///@{
 Constant ZMQ_UNKNOWN_SET_FLAG          = 10003
 Constant ZMQ_INTERNAL_ERROR            = 10004
 Constant ZMQ_INVALID_ARG               = 10005
@@ -75,7 +75,7 @@ Constant ZMQ_INVALID_LOGGING_TEMPLATE  = 10010
 Constant ZMQ_MESSAGE_FILTER_DUPLICATED = 10011
 Constant ZMQ_MESSAGE_FILTER_MISSING    = 10012
 Constant ZMQ_MESSAGE_INVALID_TYPE      = 10013
-/// @}
+///@}
 
 Constant REQ_SUCCESS                  = 0
 Constant REQ_UNKNOWN_ERROR            = 1
@@ -97,7 +97,7 @@ Constant REQ_FUNCTION_ABORTED         = 107
 
 /// @name Functions which might be useful for outside callers
 /// @anchor ZeroMQInterfaceFunctions
-/// @{
+///@{
 Function ZeroMQ_WaveExists(pathToWave)
 	string pathToWave
 
@@ -137,4 +137,4 @@ Function ZeroMQ_ShowHelp(topic)
 
 	DisplayHelpTopic topic
 End
-/// @}
+///@}


### PR DESCRIPTION
The space before @{ and @} is not accepted anymore.