### PR TITLE
ZeroMQServerSend/ZeroMQClientSend: Allow empty payloads and identity and remove identiy from router socket

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -655,7 +655,7 @@ The default socket options are:
 - ``ZMQ_RCVTIMEO``         = ``1`` (milliseconds)
 - ``ZMQ_ROUTER_MANDATORY`` = ``1`` (``Router`` only)
 - ``ZMQ_MAXMSGSIZE``       = ``1024`` (in bytes, ``Router`` only)
-- ``ZMQ_IDENTITY``         = ``zeromq xop: dealer`` (``Dealer``) and ``zeromq xop: router`` (``Router``)
+- ``ZMQ_IDENTITY``         = ``zeromq xop: dealer`` (``Dealer`` only)
 
 The ``Router``/Server expects three frames (identity, empty, payload) and the
 ``Dealer``/Client expects two frames (empty, payload) when sending/receiving

--- a/src/GlobalData.cpp
+++ b/src/GlobalData.cpp
@@ -37,10 +37,6 @@ void ApplySocketDefaults(void *s, SocketTypes st)
     return;
   case SocketTypes::Server:
   {
-    const char identity[] = "zeromq xop: router";
-    rc = zmq_setsockopt(s, ZMQ_IDENTITY, &identity, strlen(identity));
-    ZEROMQ_ASSERT(rc == 0);
-
     rc = zmq_setsockopt(s, ZMQ_ROUTER_MANDATORY, &valOne, sizeof(valOne));
     ZEROMQ_ASSERT(rc == 0);
 

--- a/src/HelperFunctions.cpp
+++ b/src/HelperFunctions.cpp
@@ -345,7 +345,7 @@ int ZeroMQClientSend(const std::string &payload)
 
   // payload
   rc = zmq_send(socket.get(), payload.c_str(), payloadLength, 0);
-  ZEROMQ_ASSERT(rc > 0);
+  ZEROMQ_ASSERT(rc >= 0);
 
   DEBUG_OUTPUT("rc={}", rc);
 
@@ -362,7 +362,7 @@ int ZeroMQServerSend(const std::string &identity, const std::string &payload)
   // identity
   int rc =
       zmq_send(socket.get(), identity.c_str(), identity.length(), ZMQ_SNDMORE);
-  ZEROMQ_ASSERT(rc > 0);
+  ZEROMQ_ASSERT(rc >= 0);
 
   // empty
   rc = zmq_send(socket.get(), nullptr, 0, ZMQ_SNDMORE);
@@ -370,7 +370,7 @@ int ZeroMQServerSend(const std::string &identity, const std::string &payload)
 
   // payload
   rc = zmq_send(socket.get(), payload.c_str(), payloadLength, 0);
-  ZEROMQ_ASSERT(rc > 0);
+  ZEROMQ_ASSERT(rc >= 0);
 
   DEBUG_OUTPUT("rc={}", rc);
 

--- a/tests/zmq_bind.ipf
+++ b/tests/zmq_bind.ipf
@@ -209,3 +209,20 @@ Function DoesNotAcceptLargeMessagesOnServerSocket()
 		CHECK_EQUAL_VAR(strlen(reply), 0)
 	endfor
 End
+
+Function AllowsEmptyIdentityAndPayload()
+
+	string reply, identity
+
+	zeromq_stop()
+	zeromq_server_bind("tcp://127.0.0.1:5555")
+
+	zeromq_client_connect("tcp://127.0.0.1:5555")
+
+	zeromq_client_send("")
+
+	reply = zeromq_server_recv(identity)
+
+	zeromq_server_send(identity, "")
+	CHECK_NO_RTE()
+End


### PR DESCRIPTION
Close #73 