### PR TITLE
IgorException::HandleException: Output message for debug only

### DIFF
--- a/src/CustomExceptions.cpp
+++ b/src/CustomExceptions.cpp
@@ -31,7 +31,7 @@ int IgorException::GetErrorCode() const
 
 int IgorException::HandleException() const
 {
-  NORMAL_OUTPUT("{}", what());
+  DEBUG_OUTPUT("{}", what());
 
   return m_errorCode;
 }


### PR DESCRIPTION
Since forever we always outputted zmq library errors to the history. While this is convenient for debugging, it is a bin annoying for users.

So let's move that type of message to debug output.

We still return with a runtime error though.